### PR TITLE
#443799: git pipeline to build master template

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -2,10 +2,9 @@ name: Build & Merge Dist Artifacts
 
 on:
   workflow_dispatch:  # allows you to launch the workflow manually
-  push:                                  # to delete
-    branches:                            # to delete
-      - 'features/mima/pipeline-to-build-master-template'  # to delete before to merge in the main, it is used just for test 
-
+  # push:
+  #   branches:
+  #     - 'features/mima/pipeline-to-build-master-template'  # Restricts push trigger to this branch for pipeline testing purposes
 
 jobs:
   build:

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -1,0 +1,52 @@
+name: Build & Merge Dist Artifacts
+
+on:
+  workflow_dispatch:  # allows you to launch the workflow manually
+  push:                                  # to delete
+    branches:                            # to delete
+      - 'features/mima/pipeline-to-build-master-template'  # to delete before to merge in the main, it is used just for test 
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Check out the current branch
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Environment setup
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22'
+
+      # Installing dependencies and the latest version of the standard library
+      - name: Install dependencies
+        run: |       
+          npm install                          
+          npm update @bsi-cx/design-standard-library-email
+
+      # Check installed standard library version
+      - name: Check installed standard library version
+        run: |
+          npm ls @bsi-cx/design-standard-library-email
+
+
+      # Buld project
+      - name: Build project
+        run: |
+          npm run build:prod
+
+      # Flatten all ZIPs into a single folder
+      - name: Collect all zip files into a flat folder
+        run: |
+          mkdir -p artifacts-flat
+          find dist -name "*.zip" -exec cp {} artifacts-flat/ \;
+
+      # Upload flat artifact 
+      - name: Upload Combined Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: master-template-email-all-builds
+          path: artifacts-flat

--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -6,6 +6,7 @@ on:
     branches:                            # to delete
       - 'features/mima/pipeline-to-build-master-template'  # to delete before to merge in the main, it is used just for test 
 
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Next
+* Add git pipeline to build master template
 * Add conditional color-scheme meta tags for Dark Mode support
 
 


### PR DESCRIPTION
This Merge Request introduces a new GitHub Actions workflow that builds the **master template** using the **latest version of the standard library** and generates a **ZIP archive containing all build artifacts**, which can be downloaded at the end of the workflow execution.

At the moment, the workflow is designed to be triggered **manually**. To run it, you need to:

* Go to **GitHub Actions**
* Select the workflow
* Click **Run workflow**

<img width="470" height="325" alt="image" src="https://github.com/user-attachments/assets/70c3163c-6036-4177-982a-1702a1023b55" />

Please note that the manual trigger **works only on the `main` branch**.

For this reason, and **for testing purposes only**, I also added an additional trigger:

```yaml
push:                                  # to delete
  branches:                            # to delete
    - 'features/mima/pipeline-to-build-master-template'  # to delete before merging into main, used only for testing
```

This trigger runs the workflow automatically on pushes to the `features/mima/pipeline-to-build-master-template` branch.
**Before merging into `main`, this trigger must be commented out or removed**, as it is intended only for development and testing.
